### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/paulirwin/neoluke/security/code-scanning/1](https://github.com/paulirwin/neoluke/security/code-scanning/1)

To fix the problem, you should explicitly declare a `permissions` block to restrict the default GITHUB_TOKEN access. The safest minimal approach is to set `permissions: { contents: read }` at the top level of the workflow. This restricts all jobs to only the read permission on repository contents, which is sufficient for building and testing code. Place this `permissions` key at the top of the file, directly under the `name:`/workflow title (line 5), or directly between `name:` and `on:`. No further code or dependency changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
